### PR TITLE
add defaults and more tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.3] (2023-04-26)
+
+- rename serialized_masked_dict() to masked_dict2str() with backward compatibility
+- add defaults for indentation and log value redaction string message
+- add more tests
+- refactor documentation
+
 ## [0.1.2] (2023-04-25)
 
 - add strong type checking

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 # -------------------------------------------------------------------------
 .PHONY: build requirements deps-update deps-init
 
+pre-commit:
+	pre-commit run --all-files
+
 requirements:
 	pre-commit autoupdate
 	python -m pip install --upgrade pip wheel

--- a/__about__.py
+++ b/__about__.py
@@ -7,7 +7,7 @@ Python Secure Logger
 
 # Increment this version number to trigger a new release. See
 # CHANGELOG.md for information on the versioning scheme.
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 # The app name will be used to define the name of the default plugin root and
 # plugin directory. To avoid conflicts between multiple locally-installed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "setuptools.build_meta:__legacy__"
 #------------------------------------------------------------------------------
 [project]
 name = "secure-logger"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
   { name="Lawrence McDaniel", email="lpm0073@gmail.com" }
 ]

--- a/secure_logger/decorators.py
+++ b/secure_logger/decorators.py
@@ -6,13 +6,17 @@ from functools import wraps
 import logging
 
 # our stuff
-from .masked_dict import serialized_masked_dict, DEFAULT_SENSITIVE_KEYS
+from .masked_dict import masked_dict2str, DEFAULT_SENSITIVE_KEYS, DEFAULT_REDACTION_MESSAGE, DEFAULT_INDENT
 
 # module initializations
 logger = logging.getLogger(__name__)
 
 
-def secure_logger(sensitive_keys: list = DEFAULT_SENSITIVE_KEYS, indent: int = 4):
+def secure_logger(
+    sensitive_keys: list = DEFAULT_SENSITIVE_KEYS,
+    indent: int = DEFAULT_INDENT,
+    message: str = DEFAULT_REDACTION_MESSAGE,
+):
     """Top level decorator, for defining input parameters."""
 
     def decorate(func):
@@ -62,7 +66,9 @@ def secure_logger(sensitive_keys: list = DEFAULT_SENSITIVE_KEYS, indent: int = 4
 
             if len(kwargs.keys()) > 0:
                 kwargs_dict_repr = "keyword args: "
-                kwargs_dict_repr += serialized_masked_dict(kwargs, sensitive_keys=sensitive_keys, indent=indent)
+                kwargs_dict_repr += masked_dict2str(
+                    kwargs, sensitive_keys=sensitive_keys, indent=indent, message=message
+                )
 
             logger.info(
                 "secure_logger: {name_spec} {args} {kwargs}".format(

--- a/secure_logger/masked_dict.py
+++ b/secure_logger/masked_dict.py
@@ -13,9 +13,17 @@ DEFAULT_SENSITIVE_KEYS = [
     "client_secret",
     "Authorization",
     "secret",
+    "access_key_id",
+    "secret_access_key",
+    "access-key-id",
+    "secret-access-key",
     "aws_access_key_id",
     "aws_secret_access_key",
+    "aws-access-key-id",
+    "aws-secret-access-key",
 ]
+DEFAULT_REDACTION_MESSAGE = "*** -- REDACTED -- ***"
+DEFAULT_INDENT = 4
 
 
 class _JSONEncoder(json.JSONEncoder):
@@ -34,7 +42,7 @@ class _JSONEncoder(json.JSONEncoder):
             return ""
 
 
-def masked_dict(obj, sensitive_keys: list = DEFAULT_SENSITIVE_KEYS) -> dict:
+def masked_dict(obj, sensitive_keys: list = DEFAULT_SENSITIVE_KEYS, message: str = DEFAULT_REDACTION_MESSAGE) -> dict:
     """
     Mask sensitive key / value in log entries.
 
@@ -51,26 +59,38 @@ def masked_dict(obj, sensitive_keys: list = DEFAULT_SENSITIVE_KEYS) -> dict:
     for key in obj:
         value = obj[key]
         if type(value) == dict:
-            value = masked_dict(value, sensitive_keys)
+            value = masked_dict(obj=value, sensitive_keys=sensitive_keys, message=message)
         to_mask[key] = value
 
     def redact(key: str, obj: dict) -> dict:
         if key in obj:
-            obj[key] = "*** -- REDACTED -- ***"
+            obj[key] = message
         return obj
 
     for key in sensitive_keys:
-        to_mask = redact(key, to_mask)
+        to_mask = redact(key=key, obj=to_mask)
     return to_mask
 
 
-def serialized_masked_dict(obj: dict, sensitive_keys: list = DEFAULT_SENSITIVE_KEYS, indent: int = 4) -> str:
+def masked_dict2str(
+    obj: dict,
+    sensitive_keys: list = DEFAULT_SENSITIVE_KEYS,
+    indent: int = DEFAULT_INDENT,
+    message: str = DEFAULT_REDACTION_MESSAGE,
+) -> str:
     """Return a JSON encoded string representation of a masked dict."""
     to_serialize = {}
     for key in obj:
         value = obj[key]
         if type(value) == dict:
-            value = masked_dict(value, sensitive_keys)
+            value = masked_dict(value, sensitive_keys, message=message)
         to_serialize[key] = value
 
-    return json.dumps(masked_dict(to_serialize, sensitive_keys=sensitive_keys), cls=_JSONEncoder, indent=indent)
+    return json.dumps(masked_dict(to_serialize, sensitive_keys, message=message), cls=_JSONEncoder, indent=indent)
+
+
+def serialized_masked_dict(
+    obj: dict, sensitive_keys: list = DEFAULT_SENSITIVE_KEYS, indent: int = DEFAULT_INDENT
+) -> str:
+    """Backwards compatibility to 0.1.2 and prior."""
+    return masked_dict2str(obj, sensitive_keys=sensitive_keys, indent=indent)

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ ABOUT = load_about()
 setup(
     name="secure-logger",
     version=ABOUT["__package_version__"],
-    description="A function decorator for beautiful and complete logging",
+    description="A decorator to generate redacted and nicely formatted log entries",
     long_description=load_readme(),
     author="Lawrence McDaniel",
     author_email="lpm0073@gmail.com",

--- a/tests.py
+++ b/tests.py
@@ -7,6 +7,7 @@ Test the three use cases that we care about.
 import logging
 
 from secure_logger.decorators import secure_logger
+from secure_logger.masked_dict import masked_dict, masked_dict2str
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -18,7 +19,7 @@ MY_SENSITIVE_KEYS = [
 ]
 
 
-@secure_logger(sensitive_keys=MY_SENSITIVE_KEYS, indent=4)
+@secure_logger()
 def test_1(msg):
     """Test 1: a simple module function."""
     print("test 1: " + msg)  # noqa: T201
@@ -32,6 +33,11 @@ class TestClass(object):
         """Test class input parameter as objects."""
         pass
 
+    @secure_logger(sensitive_keys=["aws_secret_access_key"], indent=10, message="-- Forbidden! --")
+    def test_4(self, test_dict, test_list):
+        """Test class input parameter as objects."""
+        pass
+
 
 @secure_logger()
 class Test3:
@@ -42,9 +48,11 @@ class Test3:
 
 if __name__ == "__main__":
     # test 1
+    print("test 1 - default parameters on module function")  # noqa: T201
     test_1("hello world")
 
     # test 2
+    print("test 2 - default parameters on class method")  # noqa: T201
     test_dict = {
         "insensitive_key": "you-can-see-me",
         "aws_access_key_id": "i-am-hidden",
@@ -55,4 +63,26 @@ if __name__ == "__main__":
     o.test_2(test_dict=test_dict, test_list=test_list)
 
     # test 3
-    o = Test3()
+    print("test 3 - default parameters on class definition")  # noqa: T201
+    test3 = Test3()
+
+    # test 4
+    print("test 4 - custom parameters")  # noqa: T201
+    o.test_4(test_dict=test_dict, test_list=test_list)
+
+    # test 5
+    print("test 5 - masked_dict() w defaults")  # noqa: T201
+    print(masked_dict(test_dict))  # noqa: T201
+
+    # test 6
+    print("test 6 - masked_dict() with custom parameters")  # noqa: T201
+    print(masked_dict(test_dict, sensitive_keys=["insensitive_key"], message=" -- SHAME ON YOU -- "))  # noqa: T201
+
+    # test 7
+    print("test 7 - masked_dict2str() w defaults")  # noqa: T201
+    print(masked_dict2str(test_dict))  # noqa: T201
+
+    # test 8
+    print("test 8 - masked_dict2str() w custom parameters")  # noqa: T201
+    md = masked_dict2str(test_dict, sensitive_keys=["insensitive_key"], message=" -- SHAME ON YOU -- ", indent=2)
+    print(md)  # noqa: T201


### PR DESCRIPTION
- rename serialized_masked_dict() to masked_dict2str() with backward compatibility
- add defaults for indentation and log value redaction string message
- add more tests
- refactor documentation
